### PR TITLE
feat: AWS WAFv2 fail2ban機能の実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Terraform
+.terraform/
+.terraform.lock.hcl
+*.tfstate
+*.tfstate.*
+*.tfplan
+*.tfplan.*
+.terraformrc
+terraform.rc
+
+# Variable files
+terraform.tfvars
+*.auto.tfvars
+
+# OS
+.DS_Store
+Thumbs.db
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Logs
+*.log

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,152 @@
+# WAFv2 Web ACL for CloudFront
+resource "aws_wafv2_web_acl" "fail2ban_acl" {
+  name  = "fail2ban-waf-acl"
+  scope = "CLOUDFRONT"
+
+  default_action {
+    allow {}
+  }
+
+  # Rate-based rule for fail2ban-like functionality
+  rule {
+    name     = "RateLimitRule"
+    priority = 1
+
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = var.rate_limit_requests
+        aggregate_key_type = "IP"
+
+        scope_down_statement {
+          byte_match_statement {
+            search_string = var.target_path
+            field_to_match {
+              uri_path {}
+            }
+            text_transformation {
+              priority = 0
+              type     = "LOWERCASE"
+            }
+            positional_constraint = "STARTS_WITH"
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "RateLimitRule"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # Additional security rules
+  rule {
+    name     = "AWSManagedRulesCommonRuleSet"
+    priority = 2
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "CommonRuleSetMetric"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWSManagedRulesKnownBadInputsRuleSet"
+    priority = 3
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesKnownBadInputsRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "KnownBadInputsRuleSetMetric"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "fail2banWebACL"
+    sampled_requests_enabled   = true
+  }
+
+  tags = {
+    Name = "fail2ban-waf-acl"
+  }
+}
+
+# CloudWatch Log Group for WAF logs
+resource "aws_cloudwatch_log_group" "waf_log_group" {
+  name              = "/aws/wafv2/fail2ban"
+  retention_in_days = 30
+
+  tags = {
+    Name = "fail2ban-waf-logs"
+  }
+}
+
+# WAF Logging Configuration
+resource "aws_wafv2_web_acl_logging_configuration" "waf_logging" {
+  resource_arn            = aws_wafv2_web_acl.fail2ban_acl.arn
+  log_destination_configs = [aws_cloudwatch_log_group.waf_log_group.arn]
+
+  redacted_fields {
+    single_header {
+      name = "authorization"
+    }
+  }
+
+  redacted_fields {
+    single_header {
+      name = "cookie"
+    }
+  }
+}
+
+# CloudWatch Alarm for high rate limit triggers
+resource "aws_cloudwatch_metric_alarm" "rate_limit_alarm" {
+  alarm_name          = "waf-rate-limit-high-triggers"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "BlockedRequests"
+  namespace           = "AWS/WAFV2"
+  period              = "300"
+  statistic           = "Sum"
+  threshold           = "10"
+  alarm_description   = "This metric monitors WAF rate limit rule triggers"
+  alarm_actions       = []
+
+  dimensions = {
+    WebACL = aws_wafv2_web_acl.fail2ban_acl.name
+    Rule   = "RateLimitRule"
+  }
+
+  tags = {
+    Name = "waf-rate-limit-alarm"
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,33 @@
+output "web_acl_id" {
+  description = "The ID of the WAFv2 Web ACL"
+  value       = aws_wafv2_web_acl.fail2ban_acl.id
+}
+
+output "web_acl_arn" {
+  description = "The ARN of the WAFv2 Web ACL"
+  value       = aws_wafv2_web_acl.fail2ban_acl.arn
+}
+
+output "web_acl_name" {
+  description = "The name of the WAFv2 Web ACL"
+  value       = aws_wafv2_web_acl.fail2ban_acl.name
+}
+
+output "cloudwatch_log_group_name" {
+  description = "The name of the CloudWatch log group for WAF logs"
+  value       = aws_cloudwatch_log_group.waf_log_group.name
+}
+
+output "cloudwatch_log_group_arn" {
+  description = "The ARN of the CloudWatch log group for WAF logs"
+  value       = aws_cloudwatch_log_group.waf_log_group.arn
+}
+
+output "rate_limit_configuration" {
+  description = "Rate limiting configuration details"
+  value = {
+    requests_per_5min = var.rate_limit_requests
+    block_duration    = var.block_duration_seconds
+    target_path       = var.target_path
+  }
+}

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_version = ">= 1.0"
+  
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region  = var.aws_region
+  profile = var.aws_profile
+
+  default_tags {
+    tags = {
+      Project     = "aws-wafv2-fail2ban"
+      Environment = var.environment
+      ManagedBy   = "terraform"
+    }
+  }
+}

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,0 +1,15 @@
+# AWS Configuration
+aws_region  = "us-east-1"
+aws_profile = "YukiSunaoka"
+environment = "production"
+
+# Domain Configuration
+domain_name = "download.lovelive-presents.com"
+
+# Rate Limiting Configuration
+rate_limit_requests     = 100    # Number of requests in 5-minute window
+block_duration_seconds  = 3600   # Block duration in seconds (1 hour)
+target_path            = "/website"
+
+# CloudFront Configuration
+cloudfront_distribution_id = "E1234567890ABC"  # Replace with your CloudFront distribution ID

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,47 @@
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "aws_profile" {
+  description = "AWS profile name"
+  type        = string
+  default     = "YukiSunaoka"
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+  default     = "production"
+}
+
+variable "domain_name" {
+  description = "Domain name for the website"
+  type        = string
+  default     = "download.lovelive-presents.com"
+}
+
+variable "rate_limit_requests" {
+  description = "Number of requests allowed in 5-minute window before blocking"
+  type        = number
+  default     = 100
+}
+
+variable "block_duration_seconds" {
+  description = "Duration to block IP after rate limit exceeded (in seconds)"
+  type        = number
+  default     = 3600 # 1 hour
+}
+
+variable "target_path" {
+  description = "Target path to monitor for rate limiting"
+  type        = string
+  default     = "/website"
+}
+
+variable "cloudfront_distribution_id" {
+  description = "CloudFront distribution ID to associate with WAF"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
- CloudFront + S3サイト用のレートベース制限機能を追加
- /website配下への5分間100リクエスト制限
- OWASP準拠のセキュリティルール統合
- CloudWatch Logs & Alarmsによる監視機能
- AWS SSO (YukiSunaoka) プロファイル対応
- セキュリティベストプラクティス準拠（機密情報除外）