### PR TITLE
feat: SNS・Slack通知機能の追加

### DIFF
--- a/lambda/slack_notifier.py
+++ b/lambda/slack_notifier.py
@@ -4,6 +4,7 @@ import os
 
 def handler(event, context):
     webhook_url = os.environ['SLACK_WEBHOOK_URL']
+    channel = os.environ.get('SLACK_CHANNEL', 'aws_system_notify')
     
     # Parse SNS message
     sns_message = json.loads(event['Records'][0]['Sns']['Message'])
@@ -18,6 +19,9 @@ def handler(event, context):
     
     # Create Slack message
     slack_message = {
+        "channel": f"#{channel}",
+        "username": "AWS WAF Alert",
+        "icon_emoji": ":shield:",
         "attachments": [
             {
                 "color": color,
@@ -30,12 +34,17 @@ def handler(event, context):
                         "short": True
                     },
                     {
+                        "title": "Channel",
+                        "value": f"#{channel}",
+                        "short": True
+                    },
+                    {
                         "title": "Reason",
                         "value": reason,
                         "short": False
                     }
                 ],
-                "footer": "AWS WAFv2 Fail2ban",
+                "footer": "AWS WAFv2 Fail2ban System",
                 "ts": int(context.aws_request_id.split('-')[0], 16) if context else None
             }
         ]
@@ -52,5 +61,5 @@ def handler(event, context):
     
     return {
         'statusCode': 200,
-        'body': json.dumps('Message sent to Slack')
+        'body': json.dumps(f'Message sent to Slack channel #{channel}')
     }

--- a/lambda/slack_notifier.py
+++ b/lambda/slack_notifier.py
@@ -1,0 +1,56 @@
+import json
+import urllib3
+import os
+
+def handler(event, context):
+    webhook_url = os.environ['SLACK_WEBHOOK_URL']
+    
+    # Parse SNS message
+    sns_message = json.loads(event['Records'][0]['Sns']['Message'])
+    
+    alarm_name = sns_message.get('AlarmName', 'Unknown')
+    alarm_description = sns_message.get('AlarmDescription', 'No description')
+    new_state = sns_message.get('NewStateValue', 'Unknown')
+    reason = sns_message.get('NewStateReason', 'No reason provided')
+    
+    # Determine color based on alarm state
+    color = "danger" if new_state == "ALARM" else "good" if new_state == "OK" else "warning"
+    
+    # Create Slack message
+    slack_message = {
+        "attachments": [
+            {
+                "color": color,
+                "title": f"WAF Alert: {alarm_name}",
+                "text": alarm_description,
+                "fields": [
+                    {
+                        "title": "State",
+                        "value": new_state,
+                        "short": True
+                    },
+                    {
+                        "title": "Reason",
+                        "value": reason,
+                        "short": False
+                    }
+                ],
+                "footer": "AWS WAFv2 Fail2ban",
+                "ts": int(context.aws_request_id.split('-')[0], 16) if context else None
+            }
+        ]
+    }
+    
+    # Send to Slack
+    http = urllib3.PoolManager()
+    response = http.request(
+        'POST',
+        webhook_url,
+        body=json.dumps(slack_message),
+        headers={'Content-Type': 'application/json'}
+    )
+    
+    return {
+        'statusCode': 200,
+        'body': json.dumps('Message sent to Slack')
+    }

--- a/main.tf
+++ b/main.tf
@@ -199,7 +199,7 @@ resource "aws_cloudwatch_metric_alarm" "count_threshold_alarm" {
   statistic           = "Sum"
   threshold           = var.count_threshold
   alarm_description   = "Count rule threshold exceeded - potential attack detected"
-  alarm_actions       = []
+  alarm_actions       = [aws_sns_topic.waf_notifications.arn]
 
   dimensions = {
     WebACL = aws_wafv2_web_acl.fail2ban_acl.name
@@ -222,7 +222,7 @@ resource "aws_cloudwatch_metric_alarm" "block_added_alarm" {
   statistic           = "Sum"
   threshold           = "0"
   alarm_description   = "IP address has been blocked by rate limiting rule"
-  alarm_actions       = []
+  alarm_actions       = [aws_sns_topic.waf_notifications.arn]
 
   dimensions = {
     WebACL = aws_wafv2_web_acl.fail2ban_acl.name
@@ -245,7 +245,7 @@ resource "aws_cloudwatch_metric_alarm" "block_cleared_alarm" {
   statistic           = "Sum"
   threshold           = "1"
   alarm_description   = "IP address block has been cleared"
-  alarm_actions       = []
+  alarm_actions       = [aws_sns_topic.waf_notifications.arn]
   treat_missing_data  = "breaching"
 
   dimensions = {

--- a/notifications.tf
+++ b/notifications.tf
@@ -47,6 +47,7 @@ resource "aws_lambda_function" "slack_notifier" {
   environment {
     variables = {
       SLACK_WEBHOOK_URL = var.slack_webhook_url
+      SLACK_CHANNEL     = var.slack_channel
     }
   }
 
@@ -66,6 +67,7 @@ data "archive_file" "slack_notifier_zip" {
   source {
     content = templatefile("${path.module}/lambda/slack_notifier.py", {
       webhook_url = var.slack_webhook_url
+      channel     = var.slack_channel
     })
     filename = "index.py"
   }

--- a/notifications.tf
+++ b/notifications.tf
@@ -1,0 +1,135 @@
+# SNS Topic for WAF notifications
+resource "aws_sns_topic" "waf_notifications" {
+  name = "waf-fail2ban-notifications"
+
+  tags = {
+    Name = "waf-fail2ban-notifications"
+  }
+}
+
+# SNS Topic Policy
+resource "aws_sns_topic_policy" "waf_notifications_policy" {
+  arn = aws_sns_topic.waf_notifications.arn
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "cloudwatch.amazonaws.com"
+        }
+        Action   = "sns:Publish"
+        Resource = aws_sns_topic.waf_notifications.arn
+      }
+    ]
+  })
+}
+
+# Email subscription (if email provided)
+resource "aws_sns_topic_subscription" "email_notification" {
+  count     = var.notification_email != "" ? 1 : 0
+  topic_arn = aws_sns_topic.waf_notifications.arn
+  protocol  = "email"
+  endpoint  = var.notification_email
+}
+
+# Lambda function for Slack notifications
+resource "aws_lambda_function" "slack_notifier" {
+  count         = var.slack_webhook_url != "" ? 1 : 0
+  filename      = "slack_notifier.zip"
+  function_name = "waf-slack-notifier"
+  role          = aws_iam_role.lambda_role[0].arn
+  handler       = "index.handler"
+  runtime       = "python3.9"
+  timeout       = 30
+
+  environment {
+    variables = {
+      SLACK_WEBHOOK_URL = var.slack_webhook_url
+    }
+  }
+
+  tags = {
+    Name = "waf-slack-notifier"
+  }
+
+  depends_on = [data.archive_file.slack_notifier_zip[0]]
+}
+
+# Lambda ZIP file
+data "archive_file" "slack_notifier_zip" {
+  count       = var.slack_webhook_url != "" ? 1 : 0
+  type        = "zip"
+  output_path = "slack_notifier.zip"
+  
+  source {
+    content = templatefile("${path.module}/lambda/slack_notifier.py", {
+      webhook_url = var.slack_webhook_url
+    })
+    filename = "index.py"
+  }
+}
+
+# IAM role for Lambda
+resource "aws_iam_role" "lambda_role" {
+  count = var.slack_webhook_url != "" ? 1 : 0
+  name  = "waf-slack-notifier-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+      }
+    ]
+  })
+
+  tags = {
+    Name = "waf-slack-notifier-role"
+  }
+}
+
+# IAM policy for Lambda
+resource "aws_iam_role_policy" "lambda_policy" {
+  count = var.slack_webhook_url != "" ? 1 : 0
+  name  = "waf-slack-notifier-policy"
+  role  = aws_iam_role.lambda_role[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = "arn:aws:logs:*:*:*"
+      }
+    ]
+  })
+}
+
+# SNS subscription for Lambda (if Slack webhook provided)
+resource "aws_sns_topic_subscription" "slack_notification" {
+  count     = var.slack_webhook_url != "" ? 1 : 0
+  topic_arn = aws_sns_topic.waf_notifications.arn
+  protocol  = "lambda"
+  endpoint  = aws_lambda_function.slack_notifier[0].arn
+}
+
+# Lambda permission for SNS
+resource "aws_lambda_permission" "sns_invoke" {
+  count         = var.slack_webhook_url != "" ? 1 : 0
+  statement_id  = "AllowExecutionFromSNS"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.slack_notifier[0].function_name
+  principal     = "sns.amazonaws.com"
+  source_arn    = aws_sns_topic.waf_notifications.arn
+}

--- a/shared_provider.tf
+++ b/shared_provider.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.0"
     }
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.0"
+    }
   }
 }

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -28,3 +28,7 @@ cloudfront_distribution_id = "E1234567890ABC"  # Replace with your CloudFront di
 
 # Security Configuration
 enable_managed_rules = false  # Disabled per requirement
+
+# Notification Configuration
+notification_email = "admin@example.com"  # Email for SNS notifications
+slack_webhook_url  = "https://hooks.slack.com/services/YOUR/SLACK/WEBHOOK"  # Slack webhook URL

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -32,3 +32,4 @@ enable_managed_rules = false  # Disabled per requirement
 # Notification Configuration
 notification_email = "admin@example.com"  # Email for SNS notifications
 slack_webhook_url  = "https://hooks.slack.com/services/YOUR/SLACK/WEBHOOK"  # Slack webhook URL
+slack_channel     = "aws_system_notify"   # Slack channel name (without #)

--- a/variables.tf
+++ b/variables.tf
@@ -51,3 +51,16 @@ variable "enable_managed_rules" {
   type        = bool
   default     = false
 }
+
+variable "slack_webhook_url" {
+  description = "Slack webhook URL for notifications"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "notification_email" {
+  description = "Email address for SNS notifications"
+  type        = string
+  default     = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -59,6 +59,12 @@ variable "slack_webhook_url" {
   sensitive   = true
 }
 
+variable "slack_channel" {
+  description = "Slack channel name for notifications"
+  type        = string
+  default     = "aws_system_notify"
+}
+
 variable "notification_email" {
   description = "Email address for SNS notifications"
   type        = string


### PR DESCRIPTION
- SNS Topic作成（waf-fail2ban-notifications）
- CloudWatch AlarmsにSNS通知を統合
- Slack通知用Lambda関数追加
- Email通知サポート
- 通知設定用変数追加（slack_webhook_url, notification_email）
- Archive providerサポート追加
- セキュリティ強化（sensitive変数設定）