### PR TITLE
feat: Add Microsoft Teams notification support

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ cd cloudformation
 | `notification_email` | "" | SNS通知用メールアドレス |
 | `slack_webhook_url` | "" | Slack Webhook URL |
 | `slack_channel` | "aws_system_notify" | Slackチャンネル名 |
+| `teams_webhook_url` | "" | Microsoft Teams Webhook URL |
 
 ## アーキテクチャ
 
@@ -151,6 +152,7 @@ Internet → CloudFront → WAFv2 → S3
 - **SNS Topic**: `waf-fail2ban-notifications`
 - **Email通知**: 設定したメールアドレスに配信
 - **Slack通知**: 指定チャンネルに配信
+- **Teams通知**: 指定チャンネルに配信
 
 ## セキュリティ注意事項
 

--- a/terraform/lambda/teams_notifier.py
+++ b/terraform/lambda/teams_notifier.py
@@ -1,0 +1,53 @@
+import json
+import urllib3
+import os
+from datetime import datetime
+
+def handler(event, context):
+    webhook_url = os.environ.get('TEAMS_WEBHOOK_URL')
+    
+    if not webhook_url:
+        print("Teams webhook URL not configured")
+        return {'statusCode': 200}
+    
+    try:
+        # Parse SNS message
+        sns_message = json.loads(event['Records'][0]['Sns']['Message'])
+        alarm_name = sns_message.get('AlarmName', 'Unknown')
+        new_state = sns_message.get('NewStateValue', 'Unknown')
+        reason = sns_message.get('NewStateReason', 'No reason provided')
+        
+        # Create Teams message
+        color = "FF0000" if new_state == "ALARM" else "00FF00"
+        
+        teams_message = {
+            "@type": "MessageCard",
+            "@context": "http://schema.org/extensions",
+            "themeColor": color,
+            "summary": f"WAF Alert: {alarm_name}",
+            "sections": [{
+                "activityTitle": "🛡️ AWS WAF Alert",
+                "activitySubtitle": f"Alarm: {alarm_name}",
+                "facts": [
+                    {"name": "Status", "value": new_state},
+                    {"name": "Reason", "value": reason},
+                    {"name": "Time", "value": datetime.now().strftime("%Y-%m-%d %H:%M:%S UTC")}
+                ]
+            }]
+        }
+        
+        # Send to Teams
+        http = urllib3.PoolManager()
+        response = http.request(
+            'POST',
+            webhook_url,
+            body=json.dumps(teams_message),
+            headers={'Content-Type': 'application/json'}
+        )
+        
+        print(f"Teams notification sent: {response.status}")
+        return {'statusCode': 200}
+        
+    except Exception as e:
+        print(f"Error sending Teams notification: {str(e)}")
+        return {'statusCode': 500}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,2 +1,8 @@
 # Outputs removed to minimize complexity
 # Web ACL information can be found in AWS Console if needed
+
+output "teams_lambda_function_name" {
+  description = "Name of the Teams notification Lambda function"
+  value       = var.teams_webhook_url != "" ? aws_lambda_function.teams_notifier[0].function_name : null
+  sensitive   = true
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -33,3 +33,4 @@ enable_managed_rules = false  # Disabled per requirement
 notification_email = "admin@example.com"  # Email for SNS notifications
 slack_webhook_url  = "https://hooks.slack.com/services/YOUR/SLACK/WEBHOOK"  # Slack webhook URL
 slack_channel     = "aws_system_notify"   # Slack channel name (without #)
+teams_webhook_url  = "https://outlook.office.com/webhook/YOUR/TEAMS/WEBHOOK"  # Teams webhook URL

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -70,3 +70,10 @@ variable "notification_email" {
   type        = string
   default     = ""
 }
+
+variable "teams_webhook_url" {
+  description = "Microsoft Teams webhook URL for notifications"
+  type        = string
+  default     = ""
+  sensitive   = true
+}


### PR DESCRIPTION
- Add teams_webhook_url variable for Teams integration
- Create teams_notifier.py Lambda function for Teams notifications
- Add Teams Lambda resources in notifications.tf
- Update terraform.tfvars.example with Teams configuration
- Add Teams output in outputs.tf
- Update README.md with Teams notification documentation

Security features:
- Teams webhook URL marked as sensitive
- Minimal IAM permissions for Teams Lambda
- Color-coded message cards based on alarm state